### PR TITLE
add header file for std::min (<algorithm>)

### DIFF
--- a/src/BenchmarkInfo.cpp
+++ b/src/BenchmarkInfo.cpp
@@ -4,6 +4,8 @@
 #include <celero/PimplImpl.h>
 #include <celero/Utilities.h>
 
+#include <algorithm>
+
 using namespace celero;
 
 class BenchmarkInfo::Impl


### PR DESCRIPTION
The `std::min` function is defined in header `<algorithm>` according to the C++ standard, so we should include it in this file. In particular, this fixes a compile error in Visual Studio 2013 RC.

Great library by the way, really simple to use.
