### PR TITLE
Cygwin fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,6 +164,7 @@ set(TARGET_H
 	include/celero/TestFixture.h
 	include/celero/TestVector.h
 	include/celero/Timer.h
+	include/celero/ToString.h
 	include/celero/Utilities.h
 )
 
@@ -184,6 +185,7 @@ set(TARGET_SRC
 	src/TestVector.cpp
 	src/TestFixture.cpp
 	src/Timer.cpp
+	src/ToString.cpp
 	src/Utilities.cpp
 )
 

--- a/include/celero/ToString.h
+++ b/include/celero/ToString.h
@@ -1,0 +1,56 @@
+#ifndef H_CELERO_TOSTRING_H
+#define H_CELERO_TOSTRING_H
+#ifdef __CYGWIN__
+///
+/// \author	Daniel Rother
+///
+/// \copyright Copyright 2014 John Farrier 
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+/// 
+/// http://www.apache.org/licenses/LICENSE-2.0
+/// 
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+// Implement std::to_string() here because cygwin doesn't provide it on it's own...
+#include <sstream>
+#include <string>
+#include <iostream>
+
+namespace std {
+	///
+	/// \brief	Implementation of std::to_string
+	///
+	/// Implementation of std::to_string in cases where these function is not provided by libC
+	/// e.g. Cygwin 2.850 (32 bit), gcc/libc 4.8.3-3
+	///
+	/// \author	Daniel Rother
+	///
+	template <typename T>
+	string numberToString(T number)
+	{
+	   stringstream ss;
+	   ss << number;
+	   return ss.str();
+	}
+
+	string to_string (int val);
+	string to_string (long val);
+	string to_string (long long val);
+	string to_string (unsigned val);
+	string to_string (unsigned long val);
+	string to_string (unsigned long long val);
+	string to_string (float val);
+	string to_string (double val);
+	string to_string (long double val);
+}
+
+#endif
+#endif

--- a/include/celero/Utilities.h
+++ b/include/celero/Utilities.h
@@ -28,6 +28,7 @@
 #include <cstdlib>
 #include <thread>
 #include <stdint.h>
+#include <stdio.h>
 
 #include <celero/Export.h>
 

--- a/src/Experiment.cpp
+++ b/src/Experiment.cpp
@@ -22,6 +22,9 @@
 #include <celero/PimplImpl.h>
 #include <celero/TestVector.h>
 #include <celero/Utilities.h>
+#ifdef __CYGWIN__
+	#include <celero/ToString.h>
+#endif
 
 #include <algorithm>
 #include <cassert>

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -25,6 +25,9 @@
 #else
 	#include <sys/time.h>
 #endif
+#ifdef __CYGWIN__
+	#include <celero/ToString.h>
+#endif
 
 #include <sstream>
 

--- a/src/ToString.cpp
+++ b/src/ToString.cpp
@@ -1,0 +1,59 @@
+///
+/// \author	Daniel Rother
+///
+/// \copyright Copyright 2014 John Farrier 
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+/// 
+/// http://www.apache.org/licenses/LICENSE-2.0
+/// 
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+#ifdef __CYGWIN__
+#include <celero/ToString.h>
+
+namespace std {
+	string to_string (int val) {
+		return numberToString<int>(val);
+	}
+	
+	string to_string (long val) {
+		return numberToString<long>(val);
+	}
+	
+	string to_string (long long val) {
+		return numberToString<long long>(val);
+	}
+
+	string to_string (unsigned val) {
+		return numberToString<unsigned>(val);
+	}
+
+	string to_string (unsigned long val) {
+		return numberToString<unsigned long>(val);
+	}
+
+	string to_string (unsigned long long val) {
+		return numberToString<unsigned long long>(val);
+	}
+
+	string to_string (float val) {
+		return numberToString<float>(val);
+	}
+	
+	string to_string (double val) {
+		return numberToString<double>(val);
+	}
+	
+	string to_string (long double val) {
+		return numberToString<long double>(val);
+	}
+}
+#endif


### PR DESCRIPTION
I tried to compile Celero using Windows + Cygwin (gcc 4.8.3) but
unfortunately the current Cygwin gcc/libc implementation doesn't support
std::to_string (seems to be a known bug). To overcome this limitation I
implemented the function myself.
