### PR TITLE
Remove extra comma fromm statistics struct print function (not included ...

### DIFF
--- a/src/Archive.cpp
+++ b/src/Archive.cpp
@@ -144,7 +144,7 @@ std::ostream& operator<<(std::ostream& str, ArchiveEntry::Stat const& data)
 	str << data.Skewness << ",";
 	str << data.Kurtosis << ",";
 	str << data.Min << ",";
-	str << data.Max << ",";
+	str << data.Max;
 	return str;
 }
 


### PR DESCRIPTION
Commit 3f47bbe by the same name did not include this, instead it restored a CMake file to the default status on master branch. This commit actually removes the comma. Sorry about the confusion.
