### PR TITLE
Add timed pre/post test function calls

### DIFF
--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -68,9 +68,7 @@ namespace celero
 			///
 			/// \param experimentValue The value for the experiment.  This can be ignored if the test does not utilize experiment values.
 			///
-			void TestFixture::onExperimentStart(int64_t experimentValue)
-			{
-			}
+			void onExperimentStart(int64_t experimentValue);
 
 			///
 			/// Allows the text fixture to run code that will be executed once
@@ -78,9 +76,7 @@ namespace celero
 			/// of this function IS included in the total experiment execution
 			/// time.
 			///
-			void TestFixture::onExperimentEnd()
-			{
-			}
+			void onExperimentEnd();
 
 			///
 			/// Set up the test fixture before benchmark execution.

--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -61,6 +61,28 @@ namespace celero
 			virtual std::vector<int64_t> getExperimentValues() const { return std::vector<int64_t>(); };
 
 			///
+			/// Allows the text fixture to run code that will be executed once
+			/// immediately before the benchmark. Unlike setUp, the evaluation
+			/// of this function IS included in the total experiment execution
+			/// time.
+			///
+			/// \param experimentValue The value for the experiment.  This can be ignored if the test does not utilize experiment values.
+			///
+			void TestFixture::onExperimentStart(int64_t experimentValue)
+			{
+			}
+
+			///
+			/// Allows the text fixture to run code that will be executed once
+			/// immediately after the benchmark. Unlike tearDown, the evaluation
+			/// of this function IS included in the total experiment execution
+			/// time.
+			///
+			void TestFixture::onExperimentEnd()
+			{
+			}
+
+			///
 			/// Set up the test fixture before benchmark execution.
 			///
 			/// \param experimentValue The value for the experiment.  This can be ignored if the test does not utilize experiment values.

--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -68,7 +68,7 @@ namespace celero
 			///
 			/// \param experimentValue The value for the experiment.  This can be ignored if the test does not utilize experiment values.
 			///
-			void onExperimentStart(int64_t experimentValue);
+			virtual void onExperimentStart(int64_t experimentValue);
 
 			///
 			/// Allows the text fixture to run code that will be executed once
@@ -76,7 +76,7 @@ namespace celero
 			/// of this function IS included in the total experiment execution
 			/// time.
 			///
-			void onExperimentEnd();
+			virtual void onExperimentEnd();
 
 			///
 			/// Set up the test fixture before benchmark execution.

--- a/src/TestFixture.cpp
+++ b/src/TestFixture.cpp
@@ -33,7 +33,7 @@ TestFixture::~TestFixture()
 {
 }
 
-void TestFixture::onExperimentStart()
+void TestFixture::onExperimentStart(int64_t)
 {
 }
 
@@ -67,7 +67,7 @@ uint64_t TestFixture::run(const uint64_t calls, int64_t experimentValue)
 		this->UserBenchmark();
 	}
 
-	this->onExperimentEnd(experimentValue);
+	this->onExperimentEnd();
 			
 	const auto endTime = celero::timer::GetSystemTime();
 

--- a/src/TestFixture.cpp
+++ b/src/TestFixture.cpp
@@ -33,6 +33,14 @@ TestFixture::~TestFixture()
 {
 }
 
+void TestFixture::onExperimentStart()
+{
+}
+
+void TestFixture::onExperimentEnd()
+{
+}
+
 void TestFixture::setUp(int64_t)
 {
 }
@@ -51,11 +59,15 @@ uint64_t TestFixture::run(const uint64_t calls, int64_t experimentValue)
 			
 	// Get the starting time.
 	const auto startTime = celero::timer::GetSystemTime();
+
+	this->onExperimentStart(experimentValue);
 			
 	while(operation--)
 	{
 		this->UserBenchmark();
 	}
+
+	this->onExperimentEnd(experimentValue);
 			
 	const auto endTime = celero::timer::GetSystemTime();
 


### PR DESCRIPTION
The pull request gives fixtures the ability to call a function that will be included in the timing results before (`onExperimentStart`) and after (`onExperimentEnd`) the benchmark is executed. The proposed functionality enables Celero to time thread creation and wait on asynchronous events to complete without impacting the performance too dramatically (as would be the case if `thread.wait()` were called in every benchmark execution).