### PR TITLE
Undo the re-introduction of zero-size experiments

### DIFF
--- a/src/Experiment.cpp
+++ b/src/Experiment.cpp
@@ -284,13 +284,6 @@ void Experiment::addProblemSpace(int64_t x, double scale, uint64_t iterations)
 
 size_t Experiment::getResultSize()
 {
-	if(this->pimpl->results.empty() == true)
-	{
-		auto defaultResult = std::make_shared<Result>(this);
-		defaultResult->setProblemSpaceValue(0, 1.0, this->getIterations());
-		this->pimpl->results.push_back(defaultResult);
-	}
-
 	return this->pimpl->results.size();
 }
 


### PR DESCRIPTION
In commit 353faabdf6adfdc561dc58654f4a7dc8ee46907e I fixed a bug in which the experiment size vectors are (unnecessarily) populated with experiments of zero size. In commit 999c206c9106c6a64edab037aa4809936ea7c00d (specifically [in Experiment.cpp line 261](https://github.com/DigitalInBlue/Celero/commit/999c206c#diff-8c6e05683b166f6bde31e005cf33630eL261) the offending code was re-introduced. This PR removes the offending code.