### PR TITLE
Suppress unnecessary CMake output (disrupts ccmake workflow)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 #
 # Top level makefile for Celero
 #
-# Copyright 2015 John Farrier 
+# Copyright 2015 John Farrier
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 # http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -62,43 +62,43 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Compiler Settings
 #
 
-if(MSVC) 
+if(MSVC)
   # Force to always compile with warning level 4
-  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]") 
-	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}") 
-  else() 
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4") 
-  endif() 
+  if(CMAKE_CXX_FLAGS MATCHES "/W[0-4]")
+	string(REGEX REPLACE "/W[0-4]" "/W4" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
+  else()
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4")
+  endif()
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "Compiler Flags for All Builds" FORCE) 
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "Compiler Flags for Debug Builds" FORCE) 
-  set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Compiler Flags for Release Builds" FORCE) 
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}" CACHE STRING "Compiler Flags for All Builds" FORCE)
+  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}" CACHE STRING "Compiler Flags for Debug Builds" FORCE)
+  set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Compiler Flags for Release Builds" FORCE)
 
   add_definitions("/D_CRT_SECURE_NO_WARNINGS /wd4251 /nologo")
-endif() 
- 
-if(BORLAND) 
-  set(CMAKE_CXX_FLAGS "" CACHE STRING "Compiler Flags for All Builds" FORCE) 
-  set(CMAKE_CXX_FLAGS_DEBUG "" CACHE STRING "Compiler Flags for Debug Builds" FORCE)  
-  set(CMAKE_CXX_FLAGS_RELEASE  "" CACHE STRING "Compiler Flags for Release Builds" FORCE) 
-endif() 
+endif()
 
-message (STATUS "SYSTEM: ${CMAKE_SYSTEM_NAME}")
+if(BORLAND)
+  set(CMAKE_CXX_FLAGS "" CACHE STRING "Compiler Flags for All Builds" FORCE)
+  set(CMAKE_CXX_FLAGS_DEBUG "" CACHE STRING "Compiler Flags for Debug Builds" FORCE)
+  set(CMAKE_CXX_FLAGS_RELEASE  "" CACHE STRING "Compiler Flags for Release Builds" FORCE)
+endif()
+
+#message (STATUS "SYSTEM: ${CMAKE_SYSTEM_NAME}")
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++") 
+	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
 	set(CMAKE_COMPILER_IS_GNUCXX 1)
 endif()
- 
+
 if(UNIX)
-	if(CMAKE_COMPILER_IS_GNUCXX) 
-	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -std=gnu++11 -Wall -O3" CACHE STRING "Compiler Flags for All Builds" FORCE) 
-	  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pedantic -O0 -g" CACHE STRING "Compiler Flags for Debug Builds" FORCE) 
-	  set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Compiler Flags for Release Builds" FORCE) 
+	if(CMAKE_COMPILER_IS_GNUCXX)
+	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -std=gnu++11 -Wall -O3" CACHE STRING "Compiler Flags for All Builds" FORCE)
+	  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pedantic -O0 -g" CACHE STRING "Compiler Flags for Debug Builds" FORCE)
+	  set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Compiler Flags for Release Builds" FORCE)
 	else()
-	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -std=gnu++11 -Wall -fPIC -O3" CACHE STRING "Compiler Flags for All Builds" FORCE) 
-	  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pedantic -O0 -g" CACHE STRING "Compiler Flags for Debug Builds" FORCE) 
-	  set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Compiler Flags for Release Builds" FORCE) 
-	endif() 
+	  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -std=gnu++11 -Wall -fPIC -O3" CACHE STRING "Compiler Flags for All Builds" FORCE)
+	  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -pedantic -O0 -g" CACHE STRING "Compiler Flags for Debug Builds" FORCE)
+	  set(CMAKE_CXX_FLAGS_RELEASE  "${CMAKE_CXX_FLAGS_RELEASE}" CACHE STRING "Compiler Flags for Release Builds" FORCE)
+	endif()
 endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
@@ -114,10 +114,10 @@ set(CMAKE_MINSIZEREL_POSTFIX     ""  CACHE STRING "add a postfix, usually empty 
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
-message("CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
+#message("CMAKE_CXX_COMPILER: ${CMAKE_CXX_COMPILER}")
 
-# --------------------------------------------------------------------------- 
-# --------------------------------------------------------------------------- 
+# ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
 
 #
 # Install Locations
@@ -206,24 +206,24 @@ add_library(${PROJECT_NAME} ${CELERO_USER_DEFINED_SHARED_OR_STATIC} ${TARGET_SRC
 target_link_libraries(${PROJECT_NAME} ${SYSLIBS})
 include_directories(${HEADER_PATH})
 
-install(TARGETS ${PROJECT_NAME} 
-	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/bin 
+install(TARGETS ${PROJECT_NAME}
+	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
 
-# --------------------------------------------------------------------------- 
+# ---------------------------------------------------------------------------
 # Google Test Application
-# --------------------------------------------------------------------------- 
+# ---------------------------------------------------------------------------
 
 if(CELERO_ENABLE_TESTS)
 	set(PROJECT_NAME CeleroTest)
 
-	add_executable(${PROJECT_NAME} 
+	add_executable(${PROJECT_NAME}
 		test/celero/Benchmark.test.cpp
 		test/celero/Utilities.test.cpp
 		)
 
 	# VS2012 doesn't support true variadic templates
-	if(MSVC) 
+	if(MSVC)
 		add_definitions( /D _VARIADIC_MAX=10 )
 	endif()
 
@@ -243,10 +243,10 @@ if(CELERO_ENABLE_TESTS)
 		set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Celero/Test")
 	endif()
 endif()
-	
-# --------------------------------------------------------------------------- 
+
+# ---------------------------------------------------------------------------
 # Optional
-# --------------------------------------------------------------------------- 
+# ---------------------------------------------------------------------------
 
 if(CELERO_ENABLE_FOLDERS)
 	set_property(TARGET celero PROPERTY FOLDER "Celero")


### PR DESCRIPTION
The existing message commands in `CMakeLists.txt` disrupt the workflow in ccmake by generating output about the compiler. This commit disables (comments out) these unnecessary messages.