### PR TITLE
Fix experiments/CMakeLists.txt to avoid recursing into CMakeFiles

### DIFF
--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -2,7 +2,7 @@ if(CELERO_ENABLE_EXPERIMENTS)
 	# Run the SUBDIRLIST macro located in the top level CMakeLists.txt file.
 	FILE(GLOB _ALL_FILES ./ ./*)
 	FOREACH(_FILE ${_ALL_FILES})
-	  IF(IS_DIRECTORY ${_FILE})
+	  IF(IS_DIRECTORY ${_FILE} AND NOT ${_FILE} MATCHES CMakeFiles)
 	    ADD_SUBDIRECTORY(${_FILE})
 	  ENDIF()
 	ENDFOREACH()


### PR DESCRIPTION
Without this, I get:

```
ryan@DevPC-LX:~/stuff/Celero$ cmake -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-- The C compiler identification is Clang 3.6.0
-- The CXX compiler identification is Clang 3.6.0
-- Check for working C compiler using: Ninja
-- Check for working C compiler using: Ninja -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler using: Ninja
-- Check for working CXX compiler using: Ninja -- works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- SYSTEM: Linux
CMAKE_CXX_COMPILER: /home/ryan/stuff/Downloads/clang+llvm-3.6.0-x86_64-linux-gnu/bin/clang++
CMake Error at experiments/CMakeLists.txt:6 (ADD_SUBDIRECTORY):
  The source directory

    /home/ryan/stuff/Celero/experiments/CMakeFiles

  does not contain a CMakeLists.txt file.


-- Configuring incomplete, errors occurred!
See also "/home/ryan/stuff/Celero/CMakeFiles/CMakeOutput.log".
```

even though I deleted `CMakeFiles` before running `cmake`. I'm guessing we have different versions, and yours runs `CMakeLists.txt` before creating `CMakeFiles`.

Regardless, I have to say that I've only used CMake on occasion before, so I may have done something wrong.
