### PR TITLE
Add a guard around CMake policy setting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,9 @@ PROJECT(CeleroProject)
 include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
 include(CheckIncludeFile)
-cmake_policy(SET CMP0042 OLD) # MACOSX_RPATH migration
+if(POLICY CMP0042)
+	cmake_policy(SET CMP0042 OLD) # MACOSX_RPATH migration
+endif()
 
 
 #


### PR DESCRIPTION
CMP0042 was introduced in 3.0; configuration of the project on earlier versions of CMake fails with _"Policy "CMP0042" is not known to this version of CMake"_ error. This commit adds a test that allows to skip setting this policy if it is not known to CMake.