### PR TITLE
Fixes to enable compilation on Fedora 18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ PROJECT(CeleroProject)
 include(CheckFunctionExists)
 include(CheckCXXSourceCompiles)
 include(CheckIncludeFile)
-cmake_policy(SET CMP0042 OLD) # MACOSX_RPATH migration
+#cmake_policy(SET CMP0042 OLD) # MACOSX_RPATH migration
 
 
 #

--- a/include/celero/Statistics.h
+++ b/include/celero/Statistics.h
@@ -22,6 +22,8 @@
 #include <celero/Export.h>
 #include <celero/Pimpl.h>
 
+#include <cstdint>
+
 namespace celero
 {
 	///

--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -53,7 +53,7 @@ namespace celero
 
 			enum class Constants : int64_t
 			{
-				NoProblemSpaceValue = std::numeric_limits<short>::min()
+				NoProblemSpaceValue = std::numeric_limits<int64_t>::min()
 			};
 
 			///

--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -20,7 +20,8 @@
 ///
 
 #include <cstddef>
-#include <stdint.h>
+#include <cstdint>
+#include <limits>
 
 #include <celero/Timer.h>
 #include <celero/Export.h>
@@ -52,7 +53,7 @@ namespace celero
 
 			enum class Constants : int64_t
 			{
-				NoProblemSpaceValue = INT64_MIN
+				NoProblemSpaceValue = std::numeric_limits<short>::min()
 			};
 
 			///

--- a/include/celero/Utilities.h
+++ b/include/celero/Utilities.h
@@ -24,8 +24,9 @@
 #endif
 
 #include <cstdlib>
+#include <cstdint>
+#include <cstdio>
 #include <thread>
-#include <stdint.h>
 
 #include <celero/Export.h>
 


### PR DESCRIPTION
Related to header includes, use of C-style macro constant.