### PR TITLE
Remove itoa experiment

### DIFF
--- a/experiments/DemoToString/DemoToString.cpp
+++ b/experiments/DemoToString/DemoToString.cpp
@@ -118,14 +118,6 @@ BENCHMARK(DemoToString, table, 128, 1000000)
 	celero::DoNotOptimizeAway(uint8str[x]);
 }
 
-BENCHMARK(DemoToString, itoa, 128, 1000000)
-{
-	const uint8_t x = rand() % 42;
-	char buffer[64];
-	_itoa(x, buffer, 10);
-	celero::DoNotOptimizeAway(std::string(buffer));
-}
-
 /// http://ideone.com/GkPcy
 BENCHMARK(DemoToString, hopmanFast, 128, 1000000)
 {


### PR DESCRIPTION
- According to http://stackoverflow.com/questions/3799595/itoa-function-problem, itoa is not part of the C++ standard.
This will inevitably break builds (as it did for me). It is recommended not to use it.