### PR TITLE
Ifdef itoa to resolve incompatibility issues

### DIFF
--- a/experiments/DemoToString/DemoToString.cpp
+++ b/experiments/DemoToString/DemoToString.cpp
@@ -118,6 +118,7 @@ BENCHMARK(DemoToString, table, 128, 1000000)
 	celero::DoNotOptimizeAway(uint8str[x]);
 }
 
+#ifdef _itoa // Not supported for all compilers
 BENCHMARK(DemoToString, itoa, 128, 1000000)
 {
 	const uint8_t x = rand() % 42;
@@ -125,6 +126,7 @@ BENCHMARK(DemoToString, itoa, 128, 1000000)
 	_itoa(x, buffer, 10);
 	celero::DoNotOptimizeAway(std::string(buffer));
 }
+#endif
 
 /// http://ideone.com/GkPcy
 BENCHMARK(DemoToString, hopmanFast, 128, 1000000)


### PR DESCRIPTION
- According to http://stackoverflow.com/questions/3799595/itoa-function-problem, itoa is not part of the C++ standard. This will inevitably break builds (as it did for me). It is recommended not to use it.

Signed-off-by: Cody W. Eilar <Cody.Eilar@Gmail.com>