### PR TITLE
Benchmarks' exceptions support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -153,6 +153,7 @@ set(TARGET_H
 	include/celero/CommandLine.h
 	include/celero/Console.h
 	include/celero/Distribution.h
+	include/celero/Exceptions.h
 	include/celero/Executor.h
 	include/celero/Export.h
 	include/celero/Factory.h
@@ -181,6 +182,7 @@ set(TARGET_SRC
 	src/Celero.cpp
 	src/Console.cpp
 	src/Distribution.cpp
+	src/Exceptions.cpp
 	src/Executor.cpp
 	src/JUnit.cpp
 	src/Print.cpp

--- a/include/celero/Exceptions.h
+++ b/include/celero/Exceptions.h
@@ -1,0 +1,57 @@
+#ifndef H_CELERO_EXCEPTIONS_H
+#define H_CELERO_EXCEPTIONS_H
+
+///
+/// \author	Peter Azmanov
+///
+/// \copyright Copyright 2016 Peter Azmanov
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+/// 
+/// http://www.apache.org/licenses/LICENSE-2.0
+/// 
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+#include <cstdint>
+#include <utility>
+
+namespace celero
+{
+   class TestFixture;
+
+   // Singleton storing exception settings (currently only one flag)
+   struct ExceptionSettings
+   {
+      ExceptionSettings();
+
+      // Flag indicating whether Celero should catch exceptions or not
+      static bool catchExceptions();
+      static void setCatchExceptions( bool catchExceptions );
+
+   private:
+      static ExceptionSettings & instance();
+
+   private:
+      bool catchExceptions_;
+   };
+
+   // Run test and catch SEH exceptions if they are supported by compiler
+   std::pair<bool, uint64_t> RunAndCatchSEHExc( TestFixture & test,
+                                                uint64_t threads, uint64_t calls,
+                                                int64_t experimentValue );
+
+   // Run test and catch all exceptions we can
+   std::pair<bool, uint64_t> RunAndCatchExc( TestFixture & test,
+                                             uint64_t threads, uint64_t calls,
+                                             int64_t experimentValue );
+
+}
+
+#endif

--- a/include/celero/Print.h
+++ b/include/celero/Print.h
@@ -45,6 +45,9 @@ namespace celero
 
 		void Console(const std::string& x);
 		void TableBanner();
+		void TableRowExperimentHeader(Experiment * x);
+		void TableRowFailure(const std::string& msg);
+		void TableRowProblemSpaceHeader(std::shared_ptr<Result> x);
 		void TableRowHeader(std::shared_ptr<Result> x);
 		void TableResult(std::shared_ptr<Result> x);
 	}

--- a/include/celero/Result.h
+++ b/include/celero/Result.h
@@ -119,6 +119,16 @@ namespace celero
 			///
 			bool getComplete() const;
 
+			///
+			/// Sets a flag indicating if failure happened during evaluation.
+			///
+			void setFailure(bool x);
+
+			///
+			/// Gets a flag indicating if failure happened during evaluation.
+			///
+			bool getFailure() const;
+
 		private:
 			///
 			/// Disable default constructor

--- a/src/Celero.cpp
+++ b/src/Celero.cpp
@@ -20,6 +20,7 @@
 #include <celero/Celero.h>
 #include <celero/Console.h>
 #include <celero/Benchmark.h>
+#include <celero/Exceptions.h>
 #include <celero/TestVector.h>
 #include <celero/Utilities.h>
 #include <celero/Executor.h>
@@ -94,6 +95,7 @@ void celero::Run(int argc, char** argv)
 	args.add<std::string>("junit", 'j', "Saves a JUnit XML-formatted file to the named file.", false, "");
 	args.add<std::string>("archive", 'a', "Saves or updates a result archive file.", false, "");
 	args.add<uint64_t>("distribution", 'd', "Builds a file to help characterize the distribution of measurements and exits.", false, 0);
+	args.add<bool>("catchExceptions", 'e', "Allows Celero to catch exceptions and continue processing following benchmarks.", false, true);
 	args.parse_check(argc, argv);
 	
 	if(args.exist("list") == true)
@@ -173,6 +175,10 @@ void celero::Run(int argc, char** argv)
 				celero::JUnit::Instance().add(p);
 			});
 	}
+
+	// Has a flag to catch exceptions or not been specified?
+	if (args.exist("catchExceptions"))
+		ExceptionSettings::setCatchExceptions(args.get<bool>("catchExceptions"));
 
 	print::TableBanner();
 

--- a/src/Exceptions.cpp
+++ b/src/Exceptions.cpp
@@ -1,0 +1,222 @@
+///
+/// \author	Peter Azmanov
+///
+/// \copyright Copyright 2016 Peter Azmanov
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+#include <celero/Exceptions.h>
+
+#include <celero/TestFixture.h>
+#include <celero/Console.h>
+
+#ifdef WIN32
+#include <Windows.h>
+#endif // WIN32
+
+#include <iostream>
+#include <iomanip>
+
+//
+// Macros and general logics below taken from Google Test code,
+// see gtest/internal/gtest-port.h
+//     gtest/src/gtest.cc
+//
+
+#ifndef CELERO_HAS_EXCEPTIONS
+// The user didn't tell us whether exceptions are enabled, so we need
+// to figure it out.
+# if defined(_MSC_VER) || defined(__BORLANDC__)
+// MSVC's and C++Builder's implementations of the STL use the _HAS_EXCEPTIONS
+// macro to enable exceptions, so we'll do the same.
+// Assumes that exceptions are enabled by default.
+#  ifndef _HAS_EXCEPTIONS
+#   define _HAS_EXCEPTIONS 1
+#  endif  // _HAS_EXCEPTIONS
+#  define CELERO_HAS_EXCEPTIONS _HAS_EXCEPTIONS
+# elif defined(__GNUC__) && __EXCEPTIONS
+// gcc defines __EXCEPTIONS to 1 iff exceptions are enabled.
+#  define CELERO_HAS_EXCEPTIONS 1
+# elif defined(__SUNPRO_CC)
+// Sun Pro CC supports exceptions.  However, there is no compile-time way of
+// detecting whether they are enabled or not.  Therefore, we assume that
+// they are enabled unless the user tells us otherwise.
+#  define CELERO_HAS_EXCEPTIONS 1
+# elif defined(__IBMCPP__) && __EXCEPTIONS
+// xlC defines __EXCEPTIONS to 1 iff exceptions are enabled.
+#  define CELERO_HAS_EXCEPTIONS 1
+# elif defined(__HP_aCC)
+// Exception handling is in effect by default in HP aCC compiler. It has to
+// be turned of by +noeh compiler option if desired.
+#  define CELERO_HAS_EXCEPTIONS 1
+# else
+// For other compilers, we assume exceptions are disabled to be
+// conservative.
+#  define CELERO_HAS_EXCEPTIONS 0
+# endif  // defined(_MSC_VER) || defined(__BORLANDC__)
+#endif  // CELERO_HAS_EXCEPTIONS
+
+// Determine whether the compiler supports Microsoft's Structured Exception
+// Handling.  This is supported by several Windows compilers but generally
+// does not exist on any other system.
+#ifndef CELERO_HAS_SEH
+// The user didn't tell us, so we need to figure it out.
+
+# if defined(_MSC_VER) || defined(__BORLANDC__)
+// These two compilers are known to support SEH.
+#  define CELERO_HAS_SEH 1
+# else
+// Assume no SEH.
+#  define CELERO_HAS_SEH 0
+# endif
+
+#endif  // CELERO_HAS_SEH
+
+namespace celero
+{
+   ExceptionSettings::ExceptionSettings()
+      : catchExceptions_(true)
+   {}
+
+   bool ExceptionSettings::catchExceptions()
+   {
+      return instance().catchExceptions_;
+   }
+
+   void ExceptionSettings::setCatchExceptions( bool catchExceptions )
+   {
+      instance().catchExceptions_ = catchExceptions;
+   }
+
+   ExceptionSettings & ExceptionSettings::instance()
+   {
+      static ExceptionSettings settings;
+      return settings;
+   }
+
+#if CELERO_HAS_SEH
+   namespace
+   {
+      int HandleSEH( DWORD exceptionCode )
+      {
+         // see https://support.microsoft.com/en-us/kb/185294
+         DWORD const cppExceptionCode = 0xe06d7363;
+
+         bool handle = true;
+         if (exceptionCode == EXCEPTION_BREAKPOINT)
+            handle = false;
+         else if (exceptionCode == cppExceptionCode)
+            handle = false;
+
+         return handle ? EXCEPTION_EXECUTE_HANDLER : EXCEPTION_CONTINUE_SEARCH;
+      }
+
+#define EXC_CODE_TO_STR(code) \
+   case code:                 \
+      return #code;
+
+      char const * ExceptionCodeToStr( DWORD exceptionCode )
+      {
+         switch (exceptionCode)
+         {
+         EXC_CODE_TO_STR(EXCEPTION_ACCESS_VIOLATION);
+         EXC_CODE_TO_STR(EXCEPTION_ARRAY_BOUNDS_EXCEEDED);
+         EXC_CODE_TO_STR(EXCEPTION_BREAKPOINT);
+         EXC_CODE_TO_STR(EXCEPTION_DATATYPE_MISALIGNMENT);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_DENORMAL_OPERAND);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_DIVIDE_BY_ZERO);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_INEXACT_RESULT);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_INVALID_OPERATION);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_OVERFLOW);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_STACK_CHECK);
+         EXC_CODE_TO_STR(EXCEPTION_FLT_UNDERFLOW);
+         EXC_CODE_TO_STR(EXCEPTION_GUARD_PAGE);
+         EXC_CODE_TO_STR(EXCEPTION_ILLEGAL_INSTRUCTION);
+         EXC_CODE_TO_STR(EXCEPTION_IN_PAGE_ERROR);
+         EXC_CODE_TO_STR(EXCEPTION_INT_DIVIDE_BY_ZERO);
+         EXC_CODE_TO_STR(EXCEPTION_INT_OVERFLOW);
+         EXC_CODE_TO_STR(EXCEPTION_INVALID_DISPOSITION);
+         EXC_CODE_TO_STR(EXCEPTION_INVALID_HANDLE);
+         EXC_CODE_TO_STR(EXCEPTION_NONCONTINUABLE_EXCEPTION);
+         EXC_CODE_TO_STR(EXCEPTION_PRIV_INSTRUCTION);
+         EXC_CODE_TO_STR(EXCEPTION_SINGLE_STEP);
+         EXC_CODE_TO_STR(EXCEPTION_STACK_OVERFLOW);
+         EXC_CODE_TO_STR(STATUS_UNWIND_CONSOLIDATE);
+         default:
+            return "Unknown code!";
+         }
+      }
+
+#undef EXC_CODE_TO_STR
+
+   }
+#endif  // CELERO_HAS_SEH
+
+   std::pair<bool, uint64_t> RunAndCatchSEHExc( TestFixture & test,
+                                                uint64_t threads, uint64_t calls,
+                                                int64_t experimentValue )
+   {
+#if CELERO_HAS_SEH
+      __try
+      {
+         return std::make_pair(true, test.run(threads, calls, experimentValue));
+      }
+      __except (HandleSEH(GetExceptionCode()))
+      {
+         DWORD exceptionCode = GetExceptionCode();
+         celero::console::SetConsoleColor(celero::console::ConsoleColor_Red);
+         std::cout << "SEH exception " << ExceptionCodeToStr(exceptionCode) << std::endl;
+         celero::console::SetConsoleColor(celero::console::ConsoleColor_Default);
+         return std::make_pair(false, 0);
+      }
+#else // CELERO_HAS_SEH
+      return std::make_pair(true, test.run(threads, calls, experimentValue));
+#endif  // CELERO_HAS_SEH
+   }
+
+   std::pair<bool, uint64_t> RunAndCatchExc( TestFixture & test,
+                                             uint64_t threads, uint64_t calls,
+                                             int64_t experimentValue )
+   {
+      if (ExceptionSettings::catchExceptions())
+      {
+#if CELERO_HAS_EXCEPTIONS
+         try
+         {
+            return RunAndCatchSEHExc(test, threads, calls, experimentValue);
+         }
+         catch (const std::exception& e)
+         {
+            celero::console::SetConsoleColor(celero::console::ConsoleColor_Red);
+            std::cout << "C++ exception \"" << e.what() << "\"" << std::endl;
+            celero::console::SetConsoleColor(celero::console::ConsoleColor_Default);
+         }
+         catch (...)
+         {
+            celero::console::SetConsoleColor(celero::console::ConsoleColor_Red);
+            std::cout << "Unknown C++ exception" << std::endl;
+            celero::console::SetConsoleColor(celero::console::ConsoleColor_Default);
+         }
+         return std::make_pair(false, 0);
+#else // CELERO_HAS_EXCEPTIONS
+         return RunAndCatchSEHExc(test, threads, calls, experimentValue);
+#endif // CELERO_HAS_EXCEPTIONS
+      }
+      else
+      {
+         return std::make_pair(true, test.run(threads, calls, experimentValue));
+      }
+   }
+
+}

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -132,10 +132,10 @@ std::string PrintColumn(const uint64_t x, const size_t width = PrintConstants::C
 /// http://stackoverflow.com/questions/14765155/how-can-i-easily-format-my-data-table-in-c
 /// Convert double to string with specified number of places after the decimal.
 ///
-std::string PrintColumn(const std::string& x, const size_t width = PrintConstants::ColumnWidth)
+std::string PrintStrColumnAligned(const std::string& x, const size_t width = PrintConstants::ColumnWidth, bool alignLeft = true)
 {
 	std::stringstream ss;
-	ss << std::fixed << std::left;
+	ss << std::fixed << (alignLeft ? std::left : std::right);
 
 	// fill space around displayed #
 	ss.fill(' ');
@@ -156,6 +156,16 @@ std::string PrintColumn(const std::string& x, const size_t width = PrintConstant
 	}
 
 	return ss.str();
+}
+
+std::string PrintColumn(const std::string& x, const size_t width = PrintConstants::ColumnWidth)
+{
+	return PrintStrColumnAligned(x, width);
+}
+
+std::string PrintColumnRight(const std::string& x, const size_t width = PrintConstants::ColumnWidth)
+{
+	return PrintStrColumnAligned(x, width, false);
 }
 
 std::string PrintHRule()
@@ -187,15 +197,27 @@ void celero::print::TableBanner()
 	std::cout << PrintHRule();
 }
 
-void celero::print::TableRowHeader(std::shared_ptr<Result> x)
+void celero::print::TableRowExperimentHeader(Experiment * x)
 {
 	celero::console::SetConsoleColor(celero::console::ConsoleColor_Default);
-	std::cout << PrintColumn(x->getExperiment()->getBenchmark()->getName())
-				<< PrintColumn(x->getExperiment()->getName());
+	std::cout << PrintColumn(x->getBenchmark()->getName())
+				<< PrintColumn(x->getName());
+}
 
+void celero::print::TableRowFailure(const std::string& msg)
+{
+	std::cout << PrintColumnRight("-") << PrintColumnRight("-") << PrintColumnRight("-");
+	celero::console::SetConsoleColor(celero::console::ConsoleColor_Red);
+	std::cout << msg << std::endl;
+	celero::console::SetConsoleColor(celero::console::ConsoleColor_Default);
+}
+
+void celero::print::TableRowProblemSpaceHeader(std::shared_ptr<Result> x)
+{
+	celero::console::SetConsoleColor(celero::console::ConsoleColor_Default);
 	if(x->getProblemSpaceValue() == static_cast<int64_t>(TestFixture::Constants::NoProblemSpaceValue))
 	{
-		std::cout << std::fixed << std::right << PrintColumn("Null");
+		std::cout << PrintColumnRight("Null");
 	}
 	else
 	{
@@ -204,6 +226,12 @@ void celero::print::TableRowHeader(std::shared_ptr<Result> x)
 
 	std::cout << PrintColumn(x->getExperiment()->getSamples())
 				<< PrintColumn(x->getProblemSpaceIterations());
+}
+
+void celero::print::TableRowHeader(std::shared_ptr<Result> x)
+{
+	TableRowExperimentHeader(x->getExperiment());
+	TableRowProblemSpaceHeader(x);
 }
 
 void celero::print::TableResult(std::shared_ptr<Result> x)

--- a/src/ResultTable.cpp
+++ b/src/ResultTable.cpp
@@ -51,7 +51,7 @@ class celero::ResultTable::Impl
 			// Print the header for the table.
 			if(this->ofs.is_open() == true)
 			{
-				this->ofs << "Group,Experiment,Problem Space,Samples,Iterations,Baseline,";
+				this->ofs << "Group,Experiment,Problem Space,Samples,Iterations,Failure,Baseline,";
 				this->ofs << "us/Iteration,Iterations/sec,Min (us),Mean (us),Max (us),Variance,Standard Deviation,Skewness,Kurtosis,Z Score\n";
 			}
 		}
@@ -97,7 +97,8 @@ void ResultTable::add(std::shared_ptr<Result> x)
 			<< x->getExperiment()->getName() << ","
 			<< x->getProblemSpaceValue() << ","
 			<< x->getExperiment()->getSamples() << ","
-			<< x->getProblemSpaceIterations() << ",";
+			<< x->getProblemSpaceIterations() << ","
+			<< x->getFailure() << ",";
 
 		this->pimpl->ofs << x->getBaselineMeasurement() << ","
 			<< x->getUsPerCall() << ","


### PR DESCRIPTION
This PR adds support of exceptions in google test manner.

There are several possible related questions/issues:
- Output to console: `std::exception::what()` is printed instead of measurement result columns (`"Unknown exception"` for exceptions not derived from `std::exception`). If baseline test failed with exception all related benchmarks are skipped, special table row is printed.
- Output to csv-file (`--outputTable`, `ResultTable` module): failure-column (0/1) added.
- Output to junit result xml-file (`--junit`): there is already `failure` field in run result (for comparison with objective), tests failed with exception have `<error type="exception"/>` field.
- Output to archive (`--archive`): added additional column (as in csv output). If failed test isn't found in archive then failure output is printed. Failure outputs are overwritten with valid measurements unconditionally. Failed tests don't increment total samples collected and don't change min/max statistics.
- To return failure status from test run method I used `std::pair<bool, uint64_t>` instead of `uint64_t`, it's a substitute for optional. Maybe `std::tr1::optional` should be used, but I don't know if it's cross-compatible.
- Windows SEH exceptions are supported but POSIX signals aren't. The same can be said about gtest. I suppose SEH exceptions are supported because their support is straightforward. AFAIK signals can't be handled in safe manner (even non-fatal ones).
- Recover from fatal SEH exceptions isn't tested, and may be impossible...
