### PR TITLE
Don't recurse into CMakeFiles subdirectories

### DIFF
--- a/experiments/CMakeLists.txt
+++ b/experiments/CMakeLists.txt
@@ -2,7 +2,7 @@ if(CELERO_ENABLE_EXPERIMENTS)
 	# Run the SUBDIRLIST macro located in the top level CMakeLists.txt file.
 	FILE(GLOB _ALL_FILES ./ ./*)
 	FOREACH(_FILE ${_ALL_FILES})
-	  IF(IS_DIRECTORY ${_FILE})
+	  IF((IS_DIRECTORY ${_FILE}) AND (NOT ${_FILE} MATCHES "^.*/CMakeFiles$"))
 	    ADD_SUBDIRECTORY(${_FILE})
 	  ENDIF()
 	ENDFOREACH()


### PR DESCRIPTION
Yes, this might be contraversial, but simplifies entry to Celero for those not
familiar with CMake. Without this, CMake fails with a rather cryptic error
message saying that a CMakeFiles directory contains no CMakeLists.txt.