### PR TITLE
bugfix: protect against default baseline experiment construction that doesn't…

### DIFF
--- a/src/Result.cpp
+++ b/src/Result.cpp
@@ -148,7 +148,10 @@ double Result::getBaselineMeasurement()
 
 			if(baselineExperiment != nullptr)
 			{
-				return this->getUsPerCall() / baselineExperiment->getResultByValue(this->getProblemSpaceValue())->getUsPerCall();
+				auto baselineResult = baselineExperiment->getResultByValue(this->getProblemSpaceValue());
+				if(baselineResult){
+						return this->getUsPerCall() / baselineResult->getUsPerCall();
+				}
 			}
 		}
 


### PR DESCRIPTION
This protects against default baseline experiment construction which doesn't have have a result for a given problem space value.

I also don't get why default results can even exist, and I think they should be handled top level so that the core of the library behaves more to expectation.