### PR TITLE
Added the included headers into the install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ include_directories(${HEADER_PATH})
 install(TARGETS ${PROJECT_NAME}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+install(DIRECTORY include DESTINATION include)
 
 # ---------------------------------------------------------------------------
 # Google Test Application

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,7 @@ include_directories(${HEADER_PATH})
 install(TARGETS ${PROJECT_NAME}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
 	ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
-install(DIRECTORY include DESTINATION include)
+install(DIRECTORY include DESTINATION ${CMAKE_INSTALL_PREFIX})
 
 # ---------------------------------------------------------------------------
 # Google Test Application


### PR DESCRIPTION
I intend to make a [conan](https://www.conan.io/) package. Fixing up the CMake `install()` makes the build and package parts of `conanfile.py` easier.

See https://github.com/Ignition/conan-celero-demo
