### PR TITLE
Add missing #include <functional>

### DIFF
--- a/include/celero/Utilities.h
+++ b/include/celero/Utilities.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <functional>
 #include <thread>
 
 #include <celero/Export.h>


### PR DESCRIPTION
Fix error: `function` is not a member of `std` when compiling with GCC 7.1.0.

------

Full compilation error
```
In file included from /mnt/f/dev/celero/src/Distribution.cpp:21:0:
/mnt/f/dev/celero/include/celero/Utilities.h:120:44: error: variable or field ‘DoNotOptimizeAway’ declared void
  CELERO_EXPORT void DoNotOptimizeAway(std::function<void(void)>&& x);
                                            ^~~~~~~~
/mnt/f/dev/celero/include/celero/Utilities.h:120:44: error: ‘function’ is not a member of ‘std’
/mnt/f/dev/celero/include/celero/Utilities.h:120:44: note: suggested alternative: ‘is_function’
  CELERO_EXPORT void DoNotOptimizeAway(std::function<void(void)>&& x);
                                            ^~~~~~~~
                                            is_function
/mnt/f/dev/celero/include/celero/Utilities.h:120:53: error: expected primary-expression before ‘void’
  CELERO_EXPORT void DoNotOptimizeAway(std::function<void(void)>&& x);
                                                     ^~~~
```