### PR TITLE
Make the `celero` target easy to use with CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@
 # Cmake Configuration
 #
 
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.0.2)
 
 # Project Name
 PROJECT(CeleroProject)
@@ -53,16 +53,14 @@ endif()
 if(CELERO_ENABLE_TESTS)
 	set(CELERO_ENABLE_AUTO_RUN_TESTS ON CACHE BOOL "Enable Celero tests to automatically run after building")
 	set(GTEST_DIRECTORY test/gtest-1.7.0)
-	set(GTEST_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/${GTEST_DIRECTORY}/include)
+	set(GTEST_INCLUDE_DIR ${GTEST_DIRECTORY}/include)
 	set(GTEST_LIBRARY gtest)
 	set(GTEST_MAIN_LIBRARY gtest_main)
-	include_directories(${CMAKE_CURRENT_SOURCE_DIR}/${GTEST_DIRECTORY}/include ${CMAKE_CURRENT_SOURCE_DIR}/${GTEST_DIRECTORY}/src)
+	include_directories(${GTEST_DIRECTORY}/include ${GTEST_DIRECTORY}/src)
 	ADD_SUBDIRECTORY(${GTEST_DIRECTORY})
 endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 #
 # Build and Install Settings
@@ -90,7 +88,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 # include path to be used by all projects
 #
 
-SET(HEADER_PATH ${celero_SOURCE_DIR}/include)
 
 set(PROJECT_NAME celero)
 
@@ -208,7 +205,7 @@ endif()
 
 target_link_libraries(${PROJECT_NAME} ${SYSLIBS})
 
-include_directories(${HEADER_PATH})
+target_include_directories(${PROJECT_NAME} PUBLIC include)
 
 install(TARGETS ${PROJECT_NAME}
 	LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
@@ -232,11 +229,8 @@ if(CELERO_ENABLE_TESTS)
 		add_definitions( /D _VARIADIC_MAX=10 )
 	endif()
 
-	SET(HEADER_PATH ${celero_SOURCE_DIR}/include)
-	include_directories(${HEADER_PATH})
 	include_directories(${GTEST_INCLUDE_DIR})
 
-	add_dependencies(${PROJECT_NAME} celero)
 	target_link_libraries(${PROJECT_NAME} ${GTEST_LIBRARY} ${GTEST_MAIN_LIBRARY} celero)
 
 	if(CELERO_ENABLE_AUTO_RUN_TESTS)


### PR DESCRIPTION
Modern CMake has `target_include_directories` which makes the include
directory a property of the target. Using that and a few small path changes
means that benchmarking projects can use the `celero` target easily.

Example:

```
add_subdirectory( Celero ) # Celero folder with local copy of Celero source
target_link_libraries( my_benchmark_target PRIVATE celero )
```