### PR TITLE
Add User-Defined Measurements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,7 @@ set(TARGET_H
 	include/celero/TestVector.h
 	include/celero/Timer.h
 	include/celero/Utilities.h
+	include/celero/UserDefinedMeasurement.h
 )
 
 set(TARGET_SRC
@@ -143,6 +144,7 @@ set(TARGET_SRC
 	src/ThreadTestFixture.cpp
 	src/Timer.cpp
 	src/Utilities.cpp
+	src/UserDefinedMeasurement.cpp
 )
 
 if(MSVC)

--- a/experiments/ExperimentSortingRandomIntsWithUDM/CMakeLists.txt
+++ b/experiments/ExperimentSortingRandomIntsWithUDM/CMakeLists.txt
@@ -1,0 +1,80 @@
+#
+# Standard Celero Experiment CMake File
+#
+# Copyright 2015, 2016, 2017, 2018 John Farrier 
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+# http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+#
+# CMake Configuration
+#
+
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+
+#
+# Set the experiment's name here.  Start it with "celero" and use camel case naming.
+#
+SET(PROJECT_NAME celeroExperimentSortingRandomIntsWithUDM)
+
+# Broiler Plate: Set up a CMake option.
+option(CELEROExperiment_${PROJECT_NAME} "Set to ON to build ${PROJECT_NAME}." ON)
+    
+# Broiler Plate: Test the CMake option.
+if(CELEROExperiment_${PROJECT_NAME})
+    #
+    # Add Header Files
+    #
+    set(TARGET_H
+    )
+
+    #
+    # Add Sources
+    #
+    set(TARGET_SRC
+        ExperimentSortingRandomIntsWithUDM.cpp
+    )
+
+    # Broiler Plate: Assign the src and headers to the executable.
+    add_executable(${PROJECT_NAME} 
+        ${TARGET_SRC}
+        ${TARGET_H}
+    )
+    
+    # Broiler Plate: Celero Project Dependencies
+    add_dependencies(${PROJECT_NAME} celero)
+    target_link_libraries(${PROJECT_NAME} celero)
+    
+    if(MSVC) 
+		# Broiler Plate: VS2012 doesn't support true variadic templates
+		target_compile_definitions(${PROJECT_NAME} PRIVATE /D_VARIADIC_MAX=10 )
+		target_compile_options(${PROJECT_NAME} PRIVATE /W4)
+		target_compile_options(${PROJECT_NAME} PRIVATE /D_CRT_SECURE_NO_WARNINGS)
+		target_compile_options(${PROJECT_NAME} PRIVATE /wd4251)
+		target_compile_options(${PROJECT_NAME} PRIVATE /nologo)
+	endif()
+    
+    # Broiler Plate: Add Celer's include directories.
+    include_directories(${HEADER_PATH})
+    
+    # Broiler Plate: Show here how to automate running after a build (comment in if desired)
+    # if(CELERO_RUN_EXAMPLE_ON_BUILD)
+    #	add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD COMMAND $<TARGET_FILE:${PROJECT_NAME}>)
+    # endif()
+    
+    # Broiler Plate: Set up folders for an IDE.
+    if(CELERO_ENABLE_FOLDERS)
+        set_property(TARGET ${PROJECT_NAME} PROPERTY FOLDER "Celero/Experiments")
+    endif()
+    
+endif(CELEROExperiment_${PROJECT_NAME})

--- a/experiments/ExperimentSortingRandomIntsWithUDM/ExperimentSortingRandomIntsWithUDM.cpp
+++ b/experiments/ExperimentSortingRandomIntsWithUDM/ExperimentSortingRandomIntsWithUDM.cpp
@@ -1,0 +1,218 @@
+#include <celero/Celero.h>
+#include <algorithm>
+#include <string>
+
+#ifndef WIN32
+#include <cmath>
+#include <cstdlib>
+#endif
+
+///
+/// This is the main(int argc, char** argv) for the entire celero program.
+/// You can write your own, or use this macro to insert the standard one into the project.
+///
+CELERO_MAIN
+
+class CopyCountingInt
+{
+public:
+	int64_t val;
+
+	explicit CopyCountingInt(int64_t v) : val(v)
+	{
+	}
+
+	CopyCountingInt() : val(0) {}
+
+	operator int64_t()
+	{
+		return val;
+	}
+
+	CopyCountingInt& operator=(const CopyCountingInt & other) {
+		this->val = other.val;
+		CopyCountingInt::copiesCounted++;
+		return *this;
+	}
+
+	CopyCountingInt(const CopyCountingInt & other) : val(other.val)
+	{
+		CopyCountingInt::copiesCounted++;
+	}
+
+	~CopyCountingInt() {}
+	
+	static void resetCount() {
+		CopyCountingInt::copiesCounted = 0;
+	}
+	static size_t getCount() {
+		return CopyCountingInt::copiesCounted;
+	}
+	
+private:
+	static size_t copiesCounted;
+};
+
+size_t CopyCountingInt::copiesCounted;
+
+bool operator<(const CopyCountingInt & lhs, const CopyCountingInt & rhs) {
+	return lhs.val < rhs.val;
+}
+
+///
+/// \class	SortFixture
+///	\autho	John Farrier
+///
+///	\brief	A Celero Test Fixture for sorting functions.
+///
+/// This test fixture will build a experiment of powers of two.  When executed,
+/// the selected experiment is used to create an array of the given size, then
+/// push random integers into the array.  Each sorting function will then
+/// sort the randomly generated array for timing.
+///
+///	This demo highlights how to use the ExperimentValues to build automatic
+/// test cases which can scale.  These test cases should ideally be written
+/// to a file when executed.  The resulting CSV file can be easily plotted
+/// in an application such as Microsoft Excel to show how various
+/// tests performed as their experiment scaled.
+///
+/// \code
+/// celeroDemo outfile.csv
+/// \endcode
+///
+class SortFixture : public celero::TestFixture
+{
+public:
+	class CopyCountUDM : public celero::DefaultDoubleMeasurement {
+		virtual std::string getName() const override {
+			return "# Copies";
+		}
+	};
+	
+	SortFixture()
+	{
+		this->copyCountUDM.reset(new CopyCountUDM());
+	}
+
+	virtual std::vector<celero::TestFixture::ExperimentValue> getExperimentValues() const override
+	{
+		std::vector<celero::TestFixture::ExperimentValue> problemSpace;
+
+		// ExperimentValues is part of the base class and allows us to specify
+		// some values to control various test runs to end up building a nice graph.
+		for(int64_t elements = 64; elements <= int64_t(4096); elements *= 2)
+		{
+			problemSpace.push_back(elements);
+		}
+
+		return problemSpace;
+	}
+
+	/// Before each sample, build a vector of random integers.
+	virtual void setUp(const celero::TestFixture::ExperimentValue& experimentValue) override
+	{
+		this->arraySize = experimentValue.Value;
+		this->array.resize(this->arraySize);
+		CopyCountingInt::resetCount();
+	}
+
+	// Before each iteration
+	virtual void onExperimentStart(const celero::TestFixture::ExperimentValue&) override
+	{
+		for(int i = 0; i < this->arraySize; i++)
+		{
+			this->array[i] = CopyCountingInt(celero::Random());
+		}
+	}
+
+	// After each iteration
+	virtual void onExperimentEnd() override
+	{
+		/// After each iteration, clear the vector of random integers.
+		this->array.clear();
+	}
+
+	// After each sample
+	virtual void tearDown() override
+	{
+		this->copyCountUDM->addValue(CopyCountingInt::getCount());
+	}
+
+	virtual std::vector<std::shared_ptr<celero::UserDefinedMeasurement>> getUserDefinedMeasurements() const override
+	{
+		return { this->copyCountUDM };
+	}
+	
+	std::vector<CopyCountingInt> array;
+	int64_t arraySize;
+
+	std::shared_ptr<CopyCountUDM> copyCountUDM;
+};
+
+static const int SamplesCount = 2000;
+static const int IterationsCount = 2;
+
+// For a baseline, I'll choose Bubble Sort.
+BASELINE_F(SortRandInts, BubbleSort, SortFixture, SamplesCount, IterationsCount)
+{
+	for(int x = 0; x < this->arraySize; x++)
+	{
+		for(int y = 0; y < this->arraySize - 1; y++)
+		{
+			if(this->array[y] > this->array[y + 1])
+			{
+				std::swap(this->array[y], this->array[y + 1]);
+			}
+		}
+	}
+}
+
+BENCHMARK_F(SortRandInts, SelectionSort, SortFixture, SamplesCount, IterationsCount)
+{
+	for(int x = 0; x < this->arraySize; x++)
+	{
+		auto minIdx = x;
+
+		for(int y = x; y < this->arraySize; y++)
+		{
+			if(this->array[minIdx] > this->array[y])
+			{
+				minIdx = y;
+			}
+		}
+
+		std::swap(this->array[x], this->array[minIdx]);
+	}
+}
+
+// http://www.bfilipek.com/2014/12/top-5-beautiful-c-std-algorithms.html
+BENCHMARK_F(SortRandInts, InsertionSort, SortFixture, SamplesCount, IterationsCount)
+{
+	for(auto i = std::begin(this->array); i != std::end(this->array); ++i)
+	{
+		std::rotate(std::upper_bound(std::begin(this->array), i, *i), i, std::next(i));
+	}
+}
+
+// http://www.bfilipek.com/2014/12/top-5-beautiful-c-std-algorithms.html
+template <class FwdIt, typename U>
+void quickSort(FwdIt first, FwdIt last, U cmp = U())
+{
+	auto const N = std::distance(first, last);
+	if(N <= 1)
+		return;
+	auto const pivot = std::next(first, N / 2);
+	std::nth_element(first, pivot, last, cmp);
+	quickSort(first, pivot, cmp);
+	quickSort(pivot, last, cmp);
+}
+
+BENCHMARK_F(SortRandInts, QuickSort, SortFixture, SamplesCount, IterationsCount)
+{
+	quickSort(std::begin(this->array), std::end(this->array), std::less<int64_t>());
+}
+
+BENCHMARK_F(SortRandInts, stdSort, SortFixture, SamplesCount, IterationsCount)
+{
+	std::sort(std::begin(this->array), std::end(this->array));
+}

--- a/include/celero/Celero.h
+++ b/include/celero/Celero.h
@@ -38,6 +38,7 @@
 #include <celero/Benchmark.h>
 #include <celero/GenericFactory.h>
 #include <celero/TestFixture.h>
+#include <celero/UserDefinedMeasurement.h>
 #include <celero/ThreadTestFixture.h>
 #include <celero/Utilities.h>
 

--- a/include/celero/ExperimentResult.h
+++ b/include/celero/ExperimentResult.h
@@ -27,7 +27,8 @@ namespace celero
 {
 	class Experiment;
 	class Statistics;
-
+	class UDMCollector;
+	
 	///
 	/// \class ExperimentResult
 	///
@@ -129,6 +130,10 @@ namespace celero
 		///
 		bool getFailure() const;
 
+		void setUserDefinedMeasurements(std::shared_ptr<UDMCollector> collector);
+
+		std::shared_ptr<UDMCollector> getUserDefinedMeasurements() const;
+		
 	private:
 		///
 		/// Disable default constructor

--- a/include/celero/Print.h
+++ b/include/celero/Print.h
@@ -30,7 +30,7 @@ namespace celero
 	///
 	/// \author	John farrier
 	///
-	namespace print
+	class Printer
 	{
 		// void StageBanner(const std::string& x);
 		// void GreenBar(const std::string& x);
@@ -43,6 +43,9 @@ namespace celero
 		// void SummaryTest(const std::string& x);
 		// void Summary(std::shared_ptr<celero::ExperimentResult> x);
 
+	public:
+		void initialize(std::vector<std::string> userDefinedColumns);
+		
 		void Console(const std::string& x);
 		void TableBanner();
 		void TableRowExperimentHeader(Experiment* x);
@@ -50,7 +53,17 @@ namespace celero
 		void TableRowProblemSpaceHeader(std::shared_ptr<celero::ExperimentResult> x);
 		void TableRowHeader(std::shared_ptr<celero::ExperimentResult> x);
 		void TableResult(std::shared_ptr<celero::ExperimentResult> x);
-	}
+
+		static Printer & get() {
+			static Printer p;
+			return p;
+		}
+		
+	private:
+		Printer() = default;
+		std::vector<std::string> userDefinedColumns;
+		std::vector<size_t> columnWidths;
+	};
 }
 
 #endif

--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -164,8 +164,17 @@ namespace celero
 		///
 		virtual uint64_t run(uint64_t threads, uint64_t iterations, const celero::TestFixture::ExperimentValue& experimentValue);
 
+		///
+		/// \brief If you want to use user-defined measurements, override this method to return them
+		///
+		/// This method must return a vector of pointers, one per type of user-defined measurement
+		/// that you want to measure.
+		///
 		virtual std::vector<std::shared_ptr<UserDefinedMeasurement>> getUserDefinedMeasurements() const;
 
+		///
+		/// \brief Returns the names of all user-defined measurements in this fixture.
+		///
 		std::vector<std::string> getUserDefinedMeasurementNames() const;
 
 	protected:

--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -31,6 +31,7 @@
 namespace celero
 {
 	class Benchmark;
+	class UserDefinedMeasurement;
 
 	///
 	/// \class TestFixture
@@ -162,6 +163,10 @@ namespace celero
 		/// \return Returns the number of microseconds the run took.
 		///
 		virtual uint64_t run(uint64_t threads, uint64_t iterations, const celero::TestFixture::ExperimentValue& experimentValue);
+
+		virtual std::vector<std::shared_ptr<UserDefinedMeasurement>> getUserDefinedMeasurements() const;
+
+		std::vector<std::string> getUserDefinedMeasurementNames() const;
 
 	protected:
 		/// Executed for each operation the benchmarking test is run.

--- a/include/celero/UserDefinedMeasurement.h
+++ b/include/celero/UserDefinedMeasurement.h
@@ -31,34 +31,91 @@ namespace celero
 {
 	class UserDefinedMeasurement;
 	class TestFixture;
-	using UDMAggregationFunction = std::function<double(const std::vector<std::shared_ptr<UserDefinedMeasurement>> &)>;
+	///
+	/// \brief Signature for a function that the user must supply for
+	/// every aggregation computed on a user-defined measurement
+	///
+	using UDMAggregationFunction = std::function<
+		double(const std::vector<std::shared_ptr<UserDefinedMeasurement>> &)>;
+
+	///
+	/// \brief Describes, which aggregations should be computed on a
+	/// user-defined measurement.
+	///
+	/// The string names the aggregation, the UDMAggregateFunction is
+	/// the function that will be called on the collected vector of
+	/// user-defined measurements.
+	///
 	using UDMAggregationTable = std::vector<std::pair<std::string, UDMAggregationFunction>>;
 
 	///
 	/// \class UserDefinedMeasurement
+	///
+	/// Base class that the user must derive user-defined measurements from.
 	///
 	/// \author	Lukas Barth
 	///
 	class CELERO_EXPORT UserDefinedMeasurement
 	{
 	protected:
-		///
-		/// \brief Class may never be directly instantiated
-		///
+		// Class may never be directly instantiated
 		UserDefinedMeasurement() = default;
 
 	public:
+		///
+		/// \brief Must be implemented by the user. Must return a
+		/// specification which aggregations the user wants to be
+		/// computed.
+		///
 		virtual UDMAggregationTable getAggregationInfo() const = 0;
-		virtual std::string getName() const = 0;
-	};
 
+		///
+		/// \brief Must be implemented by the user. Must return the name
+		/// of this user-defined measurement.
+		/// 
+		virtual std::string getName() const = 0; };
+
+	///
+	/// \brief Convenience class to derive simple double-based
+	/// user-defined measurements from.
+	///
+	/// For most user-defined measurements, this should be enough. The
+	/// user just needs to override getName(), and should possibly set
+	/// the according report<Aggregation> flags.
+	///
 	class CELERO_EXPORT DefaultDoubleMeasurement : public UserDefinedMeasurement {
 	public:
 		DefaultDoubleMeasurement() = default;
 
 		virtual UDMAggregationTable getAggregationInfo() const override;
+
+		///
+		/// \brief You must call this method from your fixture to add a measurement
+		///
 		void addValue(double value);
 		
+	protected:
+		///
+		/// \brief Override this to return false if you don't want the average to be reported
+		///
+		virtual bool reportAverage() const {return true;}
+		///
+		/// \brief Override this to return false if you don't want the minimum to be reported
+		///
+		virtual bool reportMin() const {return true;}
+		///
+		/// \brief Override this to return false if you don't want the maximum to be reported
+		///
+		virtual bool reportMax() const {return true;}
+		///
+		/// \brief Override this to return false if you don't want the median to be reported
+		///
+		virtual bool reportMedian() const {return true;}
+		///
+		/// \brief Override this to return false if you don't want the standard deviation to be reported
+		///
+		virtual bool reportStddev() const {return true;}
+
 	private:
 		std::vector<double> values;
 
@@ -66,6 +123,7 @@ namespace celero
 		static double getMin(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
 		static double getMax(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
 		static double getMedian(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
+		static double getStddev(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
 	};
 	
 	class UDMCollector

--- a/include/celero/UserDefinedMeasurement.h
+++ b/include/celero/UserDefinedMeasurement.h
@@ -1,0 +1,85 @@
+#ifndef H_CELERO_USERDEFINEDMEASUREMENT_H
+#define H_CELERO_USERDEFINEDMEASUREMENT_H
+
+///
+/// \author	Lukas Barth
+///
+/// \copyright Copyright 2015, 2016, 2017, 2018 John Farrier
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <celero/Export.h>
+
+namespace celero
+{
+	class UserDefinedMeasurement;
+	class TestFixture;
+	using UDMAggregationFunction = std::function<double(const std::vector<std::shared_ptr<UserDefinedMeasurement>> &)>;
+	using UDMAggregationTable = std::vector<std::pair<std::string, UDMAggregationFunction>>;
+
+	///
+	/// \class UserDefinedMeasurement
+	///
+	/// \author	Lukas Barth
+	///
+	class CELERO_EXPORT UserDefinedMeasurement
+	{
+	protected:
+		///
+		/// \brief Class may never be directly instantiated
+		///
+		UserDefinedMeasurement() = default;
+
+	public:
+		virtual UDMAggregationTable getAggregationInfo() const = 0;
+		virtual std::string getName() const = 0;
+	};
+
+	class CELERO_EXPORT DefaultDoubleMeasurement : public UserDefinedMeasurement {
+	public:
+		DefaultDoubleMeasurement() = default;
+
+		virtual UDMAggregationTable getAggregationInfo() const override;
+		void addValue(double value);
+		
+	private:
+		std::vector<double> values;
+
+		static double getAverage(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
+		static double getMin(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
+		static double getMax(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
+		static double getMedian(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms);
+	};
+	
+	class UDMCollector
+	{
+	public:
+		UDMCollector(std::shared_ptr<TestFixture> fixture);
+
+		void collect(std::shared_ptr<TestFixture> fixture);
+		std::vector<std::string> getFields(std::shared_ptr<TestFixture> fixture) const;
+		std::vector<std::pair<std::string, double>> getAggregateValues() const;
+
+	private:
+		std::unordered_map<std::string, std::vector<std::shared_ptr<UserDefinedMeasurement>>> collected;
+	};
+} // namespace celero
+
+#endif

--- a/src/Celero.cpp
+++ b/src/Celero.cpp
@@ -29,11 +29,13 @@
 #include <celero/Print.h>
 #include <celero/ResultTable.h>
 #include <celero/TestVector.h>
+#include <celero/UserDefinedMeasurement.h>
 #include <celero/Utilities.h>
 #include <cassert>
 #include <cmath>
 #include <fstream>
 #include <iostream>
+#include <set>
 
 using namespace celero;
 
@@ -181,10 +183,60 @@ void celero::Run(int argc, char** argv)
 		ExceptionSettings::SetCatchExceptions(args.get<bool>("catchExceptions"));
 	}
 
-	print::TableBanner();
-
 	// Has a run group been specified?
 	argument = args.get<std::string>("group");
+
+	// Collect all user-defined fields
+	std::set<std::string> userDefinedFields;
+	auto collectFromBenchmark = [&](std::shared_ptr<Benchmark> bmark) {
+		// Collect from baseline
+		auto baselineExperiment = bmark->getBaseline();
+		if(baselineExperiment != nullptr)
+		{
+			auto test = baselineExperiment->getFactory()->Create();
+			UDMCollector udmCollector(test);
+			for(const auto& fieldName : udmCollector.getFields(test))
+			{
+				userDefinedFields.insert(fieldName);
+			}
+		}
+
+		// Collect from all experiments
+		const auto experimentSize = bmark->getExperimentSize();
+
+		for(size_t i = 0; i < experimentSize; i++)
+		{
+			auto e = bmark->getExperiment(i);
+			assert(e != nullptr);
+
+			auto test = baselineExperiment->getFactory()->Create();
+			UDMCollector udmCollector(test);
+			for(const auto& fieldName : udmCollector.getFields(test))
+			{
+				userDefinedFields.insert(fieldName);
+			}
+		}
+	};
+
+	if(argument.empty() == false)
+	{
+		auto bmark = celero::TestVector::Instance()[argument];
+		collectFromBenchmark(bmark);
+	}
+	else
+	{
+		for(size_t i = 0; i < celero::TestVector::Instance().size(); i++)
+		{
+			auto bmark = celero::TestVector::Instance()[i];
+			collectFromBenchmark(bmark);
+		}
+	}
+
+	std::vector<std::string> userDefinedFieldsOrder(userDefinedFields.begin(), userDefinedFields.end());
+
+	Printer::get().initialize(userDefinedFieldsOrder);
+	Printer::get().TableBanner();
+	
 	if(argument.empty() == false)
 	{
 		executor::Run(argument);

--- a/src/ExperimentResult.cpp
+++ b/src/ExperimentResult.cpp
@@ -20,6 +20,7 @@
 #include <celero/Experiment.h>
 #include <celero/ExperimentResult.h>
 #include <celero/PimplImpl.h>
+#include <celero/UserDefinedMeasurement.h>
 #include <celero/Statistics.h>
 #include <celero/Timer.h>
 #include <celero/Utilities.h>
@@ -55,6 +56,8 @@ public:
 
 	/// A "failure" flag.
 	bool failure{false};
+
+	std::shared_ptr<UDMCollector> udmCollector;
 };
 
 ExperimentResult::ExperimentResult()
@@ -190,4 +193,14 @@ void ExperimentResult::setFailure(bool x)
 bool ExperimentResult::getFailure() const
 {
 	return this->pimpl->failure;
+}
+
+void ExperimentResult::setUserDefinedMeasurements(std::shared_ptr<UDMCollector> newCollector)
+{
+	this->pimpl->udmCollector = newCollector;
+}
+
+std::shared_ptr<UDMCollector> ExperimentResult::getUserDefinedMeasurements() const
+{
+	return this->pimpl->udmCollector;
 }

--- a/src/Print.cpp
+++ b/src/Print.cpp
@@ -295,7 +295,7 @@ namespace celero
 			if (udmValues.find(fieldName) == udmValues.end()) {
 				std::cout << PrintCenter("---", this->columnWidths[i + PrintConstants::NumberOfColumns]);
 			} else {
-				std::cout << PrintColumn(udmValues.at(fieldName), this->columnWidths[i + PrintConstants::NumberOfColumns], 2);
+				std::cout << PrintColumn(udmValues.at(fieldName), 2, this->columnWidths[i + PrintConstants::NumberOfColumns]);
 			}
 		}
 		

--- a/src/TestFixture.cpp
+++ b/src/TestFixture.cpp
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 #include <celero/TestFixture.h>
+#include <celero/UserDefinedMeasurement.h>
 #include <algorithm>
 #include <iostream>
 
@@ -97,4 +98,20 @@ void TestFixture::UserBenchmark()
 uint64_t TestFixture::HardCodedMeasurement() const
 {
 	return uint64_t(0);
+}
+
+std::vector<std::shared_ptr<UserDefinedMeasurement>>
+TestFixture::getUserDefinedMeasurements() const
+{
+	return {};
+}
+
+std::vector<std::string>
+TestFixture::getUserDefinedMeasurementNames() const
+{
+	std::vector<std::string> names;
+	for (auto udm : this->getUserDefinedMeasurements()) {
+		names.emplace_back(udm->getName());
+	}
+	return names;
 }

--- a/src/UserDefinedMeasurement.cpp
+++ b/src/UserDefinedMeasurement.cpp
@@ -1,0 +1,107 @@
+///
+/// \author	Lukas Barth
+///
+/// \copyright Copyright 2015, 2016, 2017, 2018 John Farrier
+///
+/// Licensed under the Apache License, Version 2.0 (the "License");
+/// you may not use this file except in compliance with the License.
+/// You may obtain a copy of the License at
+///
+/// http://www.apache.org/licenses/LICENSE-2.0
+///
+/// Unless required by applicable law or agreed to in writing, software
+/// distributed under the License is distributed on an "AS IS" BASIS,
+/// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+/// See the License for the specific language governing permissions and
+/// limitations under the License.
+///
+
+#include <assert.h>
+#include <celero/TestFixture.h>
+#include <celero/UserDefinedMeasurement.h>
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+
+using namespace celero;
+
+UDMCollector::UDMCollector(std::shared_ptr<TestFixture> fixture)
+{
+	for(auto name : fixture->getUserDefinedMeasurementNames())
+	{
+		this->collected[name] = std::vector<std::shared_ptr<UserDefinedMeasurement>>();
+	}
+}
+
+void UDMCollector::collect(std::shared_ptr<TestFixture> fixture)
+{
+	for (auto udm : fixture->getUserDefinedMeasurements()) {
+		this->collected[udm->getName()].push_back(udm);
+	}
+}
+
+std::vector<std::string> UDMCollector::getFields(std::shared_ptr<TestFixture> fixture) const
+{
+	std::vector<std::string> fields;
+
+	for (auto udm : fixture->getUserDefinedMeasurements()) {
+		for(const auto& aggDesc : udm->getAggregationInfo())
+		{
+			fields.emplace_back(std::string(udm->getName()) + std::string(" ") + std::string(aggDesc.first));
+		}
+	}
+
+	return fields;
+}
+
+std::vector<std::pair<std::string, double>>
+UDMCollector::getAggregateValues() const
+{
+	std::vector<std::pair<std::string, double>> aggregates;
+	
+	for (const auto & collectedEntry : this->collected) {
+		std::string name = collectedEntry.first;
+		std::vector<std::shared_ptr<UserDefinedMeasurement>> collectedUDMs = collectedEntry.second;
+
+		if (collectedUDMs.empty()) {
+			continue;
+		}
+
+		for(const auto& aggDesc : collectedUDMs.at(0)->getAggregationInfo())
+		{
+			std::string fieldName = std::string(name) + std::string(" ") + std::string(aggDesc.first); // TODO factor out
+			aggregates.emplace_back(fieldName, (aggDesc.second)(collectedUDMs));
+		}
+	}
+
+	return aggregates;
+}
+
+UDMAggregationTable
+DefaultDoubleMeasurement::getAggregationInfo() const
+{
+	return {
+		{"Avg", UDMAggregationFunction(&DefaultDoubleMeasurement::getAverage)}
+	};
+}
+
+double
+DefaultDoubleMeasurement::getAverage(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
+{
+	double avg = 0;
+	size_t count = 0;
+	
+	for (auto udm : udms) {
+		DefaultDoubleMeasurement * ddm = dynamic_cast<DefaultDoubleMeasurement *>(udm.get());
+		avg += std::accumulate(ddm->values.begin(), ddm->values.end(), 0.0);
+		count += ddm->values.size();
+	}
+
+	return avg / count;
+}
+
+void
+DefaultDoubleMeasurement::addValue(double value)
+{
+	this->values.push_back(value);
+}

--- a/src/UserDefinedMeasurement.cpp
+++ b/src/UserDefinedMeasurement.cpp
@@ -20,6 +20,7 @@
 #include <celero/TestFixture.h>
 #include <celero/UserDefinedMeasurement.h>
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <numeric>
 
@@ -35,7 +36,8 @@ UDMCollector::UDMCollector(std::shared_ptr<TestFixture> fixture)
 
 void UDMCollector::collect(std::shared_ptr<TestFixture> fixture)
 {
-	for (auto udm : fixture->getUserDefinedMeasurements()) {
+	for(auto udm : fixture->getUserDefinedMeasurements())
+	{
 		this->collected[udm->getName()].push_back(udm);
 	}
 }
@@ -44,32 +46,36 @@ std::vector<std::string> UDMCollector::getFields(std::shared_ptr<TestFixture> fi
 {
 	std::vector<std::string> fields;
 
-	for (auto udm : fixture->getUserDefinedMeasurements()) {
+	for(auto udm : fixture->getUserDefinedMeasurements())
+	{
 		for(const auto& aggDesc : udm->getAggregationInfo())
 		{
-			fields.emplace_back(std::string(udm->getName()) + std::string(" ") + std::string(aggDesc.first));
+			fields.emplace_back(std::string(udm->getName()) +
+													std::string(" ") + std::string(aggDesc.first));
 		}
 	}
 
 	return fields;
 }
 
-std::vector<std::pair<std::string, double>>
-UDMCollector::getAggregateValues() const
+std::vector<std::pair<std::string, double>> UDMCollector::getAggregateValues() const
 {
 	std::vector<std::pair<std::string, double>> aggregates;
-	
-	for (const auto & collectedEntry : this->collected) {
+
+	for(const auto& collectedEntry : this->collected)
+	{
 		std::string name = collectedEntry.first;
 		std::vector<std::shared_ptr<UserDefinedMeasurement>> collectedUDMs = collectedEntry.second;
 
-		if (collectedUDMs.empty()) {
+		if(collectedUDMs.empty())
+		{
 			continue;
 		}
 
 		for(const auto& aggDesc : collectedUDMs.at(0)->getAggregationInfo())
 		{
-			std::string fieldName = std::string(name) + std::string(" ") + std::string(aggDesc.first); // TODO factor out
+			std::string fieldName = std::string(name) +
+				std::string(" ") + std::string(aggDesc.first); 
 			aggregates.emplace_back(fieldName, (aggDesc.second)(collectedUDMs));
 		}
 	}
@@ -77,22 +83,46 @@ UDMCollector::getAggregateValues() const
 	return aggregates;
 }
 
-UDMAggregationTable
-DefaultDoubleMeasurement::getAggregationInfo() const
+UDMAggregationTable DefaultDoubleMeasurement::getAggregationInfo() const
 {
-	return {
-		{"Avg", UDMAggregationFunction(&DefaultDoubleMeasurement::getAverage)}
-	};
+	UDMAggregationTable table;
+
+	if(this->reportAverage())
+	{
+		table.push_back({"Avg", UDMAggregationFunction(&DefaultDoubleMeasurement::getAverage)});
+	}
+
+	if(this->reportMin())
+	{
+		table.push_back({"Min", UDMAggregationFunction(&DefaultDoubleMeasurement::getMin)});
+	}
+
+	if(this->reportMax())
+	{
+		table.push_back({"Max", UDMAggregationFunction(&DefaultDoubleMeasurement::getMax)});
+	}
+
+	if(this->reportMedian())
+	{
+		table.push_back({"Median", UDMAggregationFunction(&DefaultDoubleMeasurement::getMedian)});
+	}
+
+	if(this->reportStddev())
+	{
+		table.push_back({"StdDev", UDMAggregationFunction(&DefaultDoubleMeasurement::getStddev)});
+	}
+
+	return table;
 }
 
-double
-DefaultDoubleMeasurement::getAverage(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
+double DefaultDoubleMeasurement::getAverage(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
 {
 	double avg = 0;
 	size_t count = 0;
-	
-	for (auto udm : udms) {
-		DefaultDoubleMeasurement * ddm = dynamic_cast<DefaultDoubleMeasurement *>(udm.get());
+
+	for(auto udm : udms)
+	{
+		DefaultDoubleMeasurement* ddm = dynamic_cast<DefaultDoubleMeasurement*>(udm.get());
 		avg += std::accumulate(ddm->values.begin(), ddm->values.end(), 0.0);
 		count += ddm->values.size();
 	}
@@ -100,8 +130,100 @@ DefaultDoubleMeasurement::getAverage(std::vector<std::shared_ptr<UserDefinedMeas
 	return avg / count;
 }
 
-void
-DefaultDoubleMeasurement::addValue(double value)
+double DefaultDoubleMeasurement::getMin(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
+{
+	double min = std::nan("");
+
+	for(auto udm : udms)
+	{
+		DefaultDoubleMeasurement* ddm = dynamic_cast<DefaultDoubleMeasurement*>(udm.get());
+		if(ddm->values.empty())
+		{
+			continue;
+		}
+		min = std::fmin(min, *std::min_element(ddm->values.begin(), ddm->values.end()));
+	}
+
+	return min;
+}
+
+double DefaultDoubleMeasurement::getMax(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
+{
+	double max = std::nan("");
+
+	for(auto udm : udms)
+	{
+		DefaultDoubleMeasurement* ddm = dynamic_cast<DefaultDoubleMeasurement*>(udm.get());
+		if(ddm->values.empty())
+		{
+			continue;
+		}
+		max = std::fmax(max, *std::max_element(ddm->values.begin(), ddm->values.end()));
+	}
+
+	return max;
+}
+
+double DefaultDoubleMeasurement::getMedian(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
+{
+	std::vector<double> all_elements;
+
+	for(auto udm : udms)
+	{
+		DefaultDoubleMeasurement* ddm = dynamic_cast<DefaultDoubleMeasurement*>(udm.get());
+		all_elements.insert(all_elements.end(), ddm->values.begin(), ddm->values.end());
+	}
+
+	if(all_elements.empty())
+	{
+		return std::nan("");
+	}
+
+	std::nth_element(all_elements.begin(),
+									 all_elements.begin() + (all_elements.size() / 2),
+									 all_elements.end());
+
+	if(all_elements.size() % 2 == 1)
+	{
+		return *(all_elements.begin() + (all_elements.size() / 2 + 1));
+	}
+	else
+	{
+		double left_of_median = *std::max_element(all_elements.begin(),
+																							all_elements.begin() + (all_elements.size() / 2) - 1);
+		return (*(all_elements.begin() + (all_elements.size() / 2 + 1)) + left_of_median) / 2;
+	}
+}
+
+double DefaultDoubleMeasurement::getStddev(std::vector<std::shared_ptr<UserDefinedMeasurement>> udms)
+{
+	double avg = 0;
+	size_t count = 0;
+
+	for(auto udm : udms)
+	{
+		DefaultDoubleMeasurement* ddm = dynamic_cast<DefaultDoubleMeasurement*>(udm.get());
+		avg += std::accumulate(ddm->values.begin(), ddm->values.end(), 0.0);
+		count += ddm->values.size();
+	}
+
+	avg /= count;
+
+	std::vector<double> diff(count);
+	size_t i = 0;
+	for(auto udm : udms)
+	{
+		DefaultDoubleMeasurement* ddm = dynamic_cast<DefaultDoubleMeasurement*>(udm.get());
+		std::transform(ddm->values.begin(), ddm->values.end(),
+									 diff.begin() + i, [avg](double x) { return x - avg; });
+		i += ddm->values.size();
+	}
+
+	double sq_sum = std::inner_product(diff.begin(), diff.end(), diff.begin(), 0.0);
+	return std::sqrt(sq_sum / count);
+}
+
+void DefaultDoubleMeasurement::addValue(double value)
 {
 	this->values.push_back(value);
 }


### PR DESCRIPTION
This is a first attempt at what I suggested in https://github.com/DigitalInBlue/Celero/issues/126

It has become a larger change than I expected, but that's also because I needed to change a lot in the printing code to accommodate for the new columns. I haven't yet added output of the user-defined measurements in the other two formats; this will follow if you like what I have so far.

There are some points which I'm not completely happy with, but for which I don't see a perfect solution:

* The code collecting all the additional fields to be printed does not feel like it belongs in `Celero.cpp`, however it also doesn't fit into `Executor.cpp` - or anywhere else, really. Maybe this should be part of the `UDMCollector`?
* The `UDMCollector` itself feels a bit like it should be part of `ExperimentResult`. However, at the time the `ExperimentResult` objects are created, we don't have the `TestFixture` objects yet (which I need for the `UDMCollector`…)

Also, I didn't find any specification of what code style you prefer. I tried to go with what I found and keep it consistent.