### PR TITLE
Add missing <string> include to use std::string

### DIFF
--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -24,6 +24,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <string>
 #include <vector>
 
 // This must be included last.


### PR DESCRIPTION
This causes compile failures with VS2019 previews, where \<vector> no longer includes \<string>.