### PR TITLE
Removed curses.h include

### DIFF
--- a/src/Console.cpp
+++ b/src/Console.cpp
@@ -24,7 +24,6 @@ using namespace celero;
 #include <Windows.h>
 #include <stdio.h>
 #else
-#include <curses.h>
 #include <iostream>
 #endif
 


### PR DESCRIPTION
See #134. Removed curses.h from Console.cpp