### PR TITLE
Cleanup some compiler issues on MacOS.

### DIFF
--- a/include/celero/ThreadLocal.h
+++ b/include/celero/ThreadLocal.h
@@ -19,10 +19,8 @@
 /// limitations under the License.
 ///
 
-#ifndef thread_local
-
-#if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
-#define thread_local _Thread_local
+#if __cplusplus >= 201103L || defined _MSC_VER && _MSC_VER >= 1900
+/* do nothing, thread_local is a c++11 keyword */
 #elif defined _WIN32 && (defined _MSC_VER || defined __ICL || defined __DMC__ || defined __BORLANDC__)
 #define thread_local __declspec(thread)
 /* note that ICC (linux) and Clang are covered by __GNUC__ */
@@ -30,7 +28,6 @@
 #define thread_local __thread
 #else
 #error "Cannot define thread_local"
-#endif
 #endif
 
 #endif

--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -29,6 +29,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <array>
+#include <cstring>
 #else
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
In file include/celero/ThreadLocal.h:
* `thread_local` is a C++ keyword so using an #ifdef check for its
  existence is not reliable. Instead, check for C++11 support to
  determine if `thread_local` is already defined. See here
  https://stackoverflow.com/questions/5047971/how-do-i-check-for-c11-support.
* Also the check `#if __STDC_VERSION__ >= 201112` is not meaningful,
  since presumably Celero is being compiled with a C++ compiler, so it
  has been removed.

In file src/Memory.cpp:
* Added include for `<cstring>` so that `strlen` and `strncmp` are
  defined for Apple environment.

Fixes #140