### PR TITLE
TestFixture: Use reference in range-for.

### DIFF
--- a/src/TestFixture.cpp
+++ b/src/TestFixture.cpp
@@ -135,7 +135,7 @@ std::vector<std::string> TestFixture::getUserDefinedMeasurementNames() const
 
 	if(udms.empty() == false)
 	{
-		for(const auto udm : udms)
+		for(const auto& udm : udms)
 		{
 			names.emplace_back(udm->getName());
 		}


### PR DESCRIPTION
This fixes the compilation error in
https://github.com/DigitalInBlue/Celero/issues/142