### PR TITLE
Fix mismatching MT runtime for static MSVC library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ macro(CeleroSetDefaultCompilerOptions)
 					target_compile_options(${PROJECT_NAME} PRIVATE /MD$<$<CONFIG:Debug>:d>)
 				endif()
 			else()
-				target_compile_options(${PROJECT_NAME} PRIVATE /MD$<$<CONFIG:Debug>:d>)
+				target_compile_options(${PROJECT_NAME} PRIVATE /MT$<$<CONFIG:Debug>:d>)
 			endif()
 		endif()
 


### PR DESCRIPTION
Set `/MT` for static library build which was accidentally broken by 97c6aa9905d92d8973a84807d869f231f91506e0