### PR TITLE
fix missing include with gcc 11.1.0

### DIFF
--- a/include/celero/TestFixture.h
+++ b/include/celero/TestFixture.h
@@ -25,6 +25,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <memory>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
got a missing include.
not sure why, maybe i got several compiler installations mixed up.
regardless it's good to have it instead of relying on other headers to implicitly include it.