### PR TITLE
Fix an unused variable warning in macOS

### DIFF
--- a/src/Memory.cpp
+++ b/src/Memory.cpp
@@ -58,7 +58,10 @@ using namespace celero;
 
 #ifdef _WIN32
 #else
+
+#ifndef __APPLE__
 constexpr int64_t Kilobytes2Bytes{1024};
+#endif
 
 namespace celero
 {


### PR DESCRIPTION
This MR limits the scope of the `Kilobytes2Bytes` variable to Linux environments to address an unused variable warning on macOS.