### PR TITLE
fix(cmake): Remove unnecessary MSVC property

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,7 +205,6 @@ else()
 endif()
 
 CeleroSetDefaultCompilerOptions()
-target_compile_options(${PROJECT_NAME} PRIVATE /wd4251)
 
 target_link_libraries(${PROJECT_NAME} ${SYSLIBS})
 


### PR DESCRIPTION
Celero is not compiling on macOS using cmake because of an unnecessary MSVC property.