### PR TITLE
Remove unused variable error

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -24,11 +24,12 @@
 #ifdef _WIN32
 #include <windows.h>
 LARGE_INTEGER QPCFrequency;
+
+constexpr double QPCFrequencyQuadPartMultiple = 1000000.0;
+
 #else
 #include <chrono>
 #endif
-
-constexpr double QPCFrequencyQuadPartMultiple = 1000000.0;
 
 uint64_t celero::timer::GetSystemTime()
 {


### PR DESCRIPTION
When building with warnings as errors, there was an unused variable error on mac/linux. This PR changes the variable to only be defined on windows, where it is used.