### PR TITLE
Add `[[maybe_unused]]` to `QPCFrequencyQuadPartMultiple`

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -28,7 +28,7 @@ LARGE_INTEGER QPCFrequency;
 #include <chrono>
 #endif
 
-constexpr double QPCFrequencyQuadPartMultiple = 1000000.0;
+[[maybe_unused]] constexpr double QPCFrequencyQuadPartMultiple = 1000000.0;
 
 uint64_t celero::timer::GetSystemTime()
 {


### PR DESCRIPTION
This change adds the `[[maybe_unused]]` attribute to the `QPCFrequencyQuadPartMultiple` constant. On non-Windows platforms, this variable is not used, and without the attribute, compilation fails because warnings are treated as errors.

## Impact:

Ensures cross-platform compilation without unused variable warnings.
No functional changes on Windows or other platforms.

## Notes:

This is purely a compilation fix; the runtime behavior remains unchanged.